### PR TITLE
More walls in scene.

### DIFF
--- a/shaders/phong.frag
+++ b/shaders/phong.frag
@@ -18,7 +18,7 @@ struct PointLight {
 };
 
 //hardcoded for now
-PointLight light = PointLight(15.0, vec3(1.0, 1.0, 1.0));
+PointLight light = PointLight(45.0, vec3(1.0, 1.0, 1.0));
 
 void main()
 {

--- a/src/renderer/mainpass.rs
+++ b/src/renderer/mainpass.rs
@@ -115,7 +115,7 @@ impl MainPass
 		let descriptor_sizes = [
 			vk::DescriptorPoolSize {
 				typ: vk::DescriptorType::CombinedImageSampler,
-				descriptor_count: 8,
+				descriptor_count: 14,
 			},
 			vk::DescriptorPoolSize {
 				typ: vk::DescriptorType::UniformBuffer,
@@ -128,7 +128,7 @@ impl MainPass
 			flags: Default::default(),
 			pool_size_count: descriptor_sizes.len() as u32,
 			p_pool_sizes: descriptor_sizes.as_ptr(),
-			max_sets: 5, // TODO figure out how to properly do this
+			max_sets: 8, // TODO figure out how to properly do this
 		};
 		let descriptor_pool;
 		unsafe {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,7 +1,7 @@
 use ash::vk;
 use cgmath::{Deg, Matrix4, Point3, Quaternion, Vector3};
 use cgmath::prelude::*;
-use object::{DrawObject, Drawable, Rotation};
+use object::{DrawObject, Drawable, Position, Rotation};
 use renderer::{MainPass, RenderState};
 use std::f32;
 
@@ -21,21 +21,36 @@ impl Scene
 		let cuboid = DrawObject::new_cuboid(rs, mp, Point3::new(1.0, 0.0, -4.0), 2.0, 2.0, 2.0);
 		scene.objects.push(cuboid);
 
-		let mut right_wall = DrawObject::new_quad(rs, mp, Point3::new(10.0, 0.0, 0.0), 10.0, 10.0);
-		right_wall.globally_rotate(Quaternion::from_axis_angle(Vector3::new(0.0, 1.0, 0.0), Deg(-90.0)));
-		scene.objects.push(right_wall);
+		let points = vec![
+			Point3::new(1.0, 0.0, 0.0),
+			Point3::new(-1.0, 0.0, 0.0),
+			Point3::new(0.0, 1.0, 0.0),
+			Point3::new(0.0, -1.0, 0.0),
+			Point3::new(0.0, 0.0, -1.0),
+			Point3::new(0.0, 0.0, 1.0),
+		];
 
-		let mut left_wall = DrawObject::new_quad(rs, mp, Point3::new(-10.0, 0.0, 0.0), 10.0, 10.0);
-		left_wall.globally_rotate(Quaternion::from_axis_angle(Vector3::new(0.0, 1.0, 0.0), Deg(90.0)));
-		left_wall.globally_rotate(Quaternion::from_axis_angle(Vector3::new(1.0, 0.0, 0.0), Deg(180.0)));
-		scene.objects.push(left_wall);
+		let directions = vec![
+			Vector3::new(0.0, -1.0, 0.0),
+			Vector3::new(0.0, 1.0, 0.0),
+			Vector3::new(1.0, 0.0, 0.0),
+			Vector3::new(-1.0, 0.0, 0.0),
+			Vector3::new(0.0, 0.0, 1.0),
+			Vector3::new(0.0, 0.0, 1.0),
+		];
 
-		let mut floor = DrawObject::new_quad(rs, mp, Point3::new(0.0, -10.0, 0.0), 10.0, 10.0);
-		floor.globally_rotate(Quaternion::from_axis_angle(Vector3::new(1.0, 0.0, 0.0), Deg(-90.0)));
-		floor.globally_rotate(Quaternion::from_axis_angle(Vector3::new(0.0, 1.0, 0.0), Deg(-90.0)));
-		scene.objects.push(floor);
+		for i in 0..6 {
+			let x:f32 = points[i].x;
+			let y:f32 = points[i].y;
+			let z:f32 = points[i].z;
+			let mut wall = DrawObject::new_quad(rs, mp, Point3::new(0., 0., 0.), 20.0, 20.0);
+			wall.set_rotation(Quaternion::from_axis_angle( directions[i], Deg(90.0)));
+			if i==5 { wall.set_rotation(Quaternion::new( 0.0, 0.0, 1.0, 0.0 )); }
+			wall.set_position( Point3::new(20.*x, 20.*y, 20.*z) );	
+			scene.objects.push(wall);
+		}
 
-		scene
+		return scene
 	}
 
 	pub fn update(&mut self)


### PR DESCRIPTION
increased point light distance.
made 6 walls in scene with cube.
increased number of CombinedImageSamplers from 8 to 14 and max_sets to 8 to allow it.

Since all wall faces use same material (textures + shader + ubo ), we should instead only create enough descriptors to support drawing 1. (2 combined samplers + 1 shader + 1 ubo = 1 set) 
Not sure if I got numbers right there, but im guessing the we need at least 2 combined samplers for the normal map + texture map.

Then later bind them in command buffer creation for each mesh/quad we draw.
