### PR TITLE
Replaces winit with SDL2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ debug_layer = [] # enables debug layer
 ash = "0.31.0"
 bit-vec = "0.6.2"
 cgmath = "0.17.0"
-image = "0.23.7"
+image = "0.23.8"
+sdl2 = { version = "0.34.2", features = ["bundled", "static-link"] }
 serde = "1.0.114"
 serde_derive = "1.0.114"
-serde_json = "1.0.56"
-winit = "0.19.5"
+serde_json = "1.0.57"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ $ sudo apt install vulkan-validationlayers vulkan-tools
 
 Then verify that they are available to your vulkan instance:
 ~~~bash
-$ vulkaninfo | grep VK_LAYER_LUNARG_standard_validation
-VK_LAYER_LUNARG_standard_validation (LunarG Standard Validation) Vulkan version 1.1.101, layer version 1
+$ vulkaninfo | grep VK_LAYER_KHRONOS_validation
+VK_LAYER_KHRONOS_validation (Khronos Validation Layer) Vulkan version 1.2.141, layer version 1:
 ~~~
 
 ### SDL2

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The original assets of this project are licensed under [CC BY 4.0](assets/origin
 
 Contribute:
 ===========
-Please create pull requests with reviewers for commits to the master branch. This is currently enforced by GitHub option.  
+Please create pull requests with reviewers for commits to the main branch. This is currently enforced by GitHub option.  
 Please also use rustfmt on the code before opening code reviews. The project is currently using the nightly rustfmt,
 which is used as follows:
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ $ vulkaninfo | grep VK_LAYER_LUNARG_standard_validation
 VK_LAYER_LUNARG_standard_validation (LunarG Standard Validation) Vulkan version 1.1.101, layer version 1
 ~~~
 
+### SDL2
+This project uses the SDL2 Rust crate in "bundled" mode. It therefore requires a C-compiler and cmake installed:
+~~~
+$ sudo apt install gcc cmake
+~~~
+In addition, the development headers for the current window system need to be available.  
+For X11, this requires:
+~~~
+$ sudo apt install libx11-dev libxext-dev
+~~~
+See [the rust-sdl2 github page](https://github.com/Rust-SDL2/rust-sdl2) for more details.
+
 Compile:
 --------
 ~~~bash

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -16,7 +16,7 @@ pub struct Config
 	pub horizontal_fov: u32,
 	pub mouse_invert_x: bool,
 	pub mouse_invert_y: bool,
-	pub mouse_sensitivity: f64,
+	pub mouse_sensitivity: f32,
 	pub render_width: u32,
 	pub render_height: u32,
 	pub window_width: u32,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,7 +9,7 @@ mod transform;
 pub use self::component::{Component, ComponentType, DrawComponent, TransformComponent};
 pub use self::config::Config;
 pub use self::game_object::GameObject;
-pub use self::input::{Action, ActionType, InputHandler};
+pub use self::input::{Action, ActionType, InputHandler, KeyEventState};
 pub use self::material::Material;
 pub use self::mesh::{Mesh, Vertex};
 pub use self::transform::{Transform, Transformable};
@@ -53,6 +53,6 @@ pub trait InputConsumer
 
 pub trait MouseConsumer
 {
-	fn register_mouse_settings(&mut self, mouse_invert: (bool, bool), mouse_sensitivity: f64);
-	fn consume(&mut self, mouse_delta: (f64, f64));
+	fn register_mouse_settings(&mut self, mouse_invert: (bool, bool), mouse_sensitivity: f32);
+	fn consume(&mut self, mouse_delta: (i32, i32));
 }

--- a/src/game/camera.rs
+++ b/src/game/camera.rs
@@ -6,7 +6,7 @@ pub struct Camera
 {
 	pub object: GameObject,
 	mouse_invert: (bool, bool),
-	mouse_sensitivity: f64,
+	mouse_sensitivity: f32,
 }
 
 impl Camera
@@ -108,15 +108,16 @@ impl InputConsumer for Camera
 
 impl MouseConsumer for Camera
 {
-	fn register_mouse_settings(&mut self, mouse_invert: (bool, bool), mouse_sensitivity: f64)
+	fn register_mouse_settings(&mut self, mouse_invert: (bool, bool), mouse_sensitivity: f32)
 	{
 		self.mouse_invert = mouse_invert;
 		self.mouse_sensitivity = mouse_sensitivity;
 	}
 
-	fn consume(&mut self, mouse_delta: (f64, f64))
+	fn consume(&mut self, mouse_delta: (i32, i32))
 	{
-		let (mut mouse_yaw, mut mouse_pitch) = mouse_delta;
+		let mut mouse_yaw = mouse_delta.0 as f32;
+		let mut mouse_pitch = mouse_delta.1 as f32;
 		let (x_invert, y_invert) = self.mouse_invert;
 		// Yaw and pitch will be in the opposite direction of mouse delta
 		mouse_yaw *= if x_invert
@@ -138,8 +139,8 @@ impl MouseConsumer for Camera
 
 		if let Some(transform_comp) = self.object.get_component::<TransformComponent>()
 		{
-			transform_comp.yaw(mouse_yaw as f32);
-			transform_comp.pitch(mouse_pitch as f32);
+			transform_comp.yaw(mouse_yaw);
+			transform_comp.pitch(mouse_pitch);
 		}
 	}
 }

--- a/src/renderer/mainpass.rs
+++ b/src/renderer/mainpass.rs
@@ -76,24 +76,16 @@ impl MainPass
 			color_attachment_count: 1,
 			p_color_attachments: &color_attachment_ref,
 			p_depth_stencil_attachment: &depth_attachment_ref,
-			flags: Default::default(),
 			pipeline_bind_point: vk::PipelineBindPoint::GRAPHICS,
-			input_attachment_count: 0,
-			p_input_attachments: ptr::null(),
-			p_resolve_attachments: ptr::null(),
-			preserve_attachment_count: 0,
-			p_preserve_attachments: ptr::null(),
+			..Default::default()
 		};
 		let renderpass_create_info = vk::RenderPassCreateInfo {
 			s_type: vk::StructureType::RENDER_PASS_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			attachment_count: renderpass_attachments.len() as u32,
 			p_attachments: renderpass_attachments.as_ptr(),
 			subpass_count: 1,
 			p_subpasses: &subpass,
-			dependency_count: 0,
-			p_dependencies: ptr::null(),
+			..Default::default()
 		};
 		let renderpass;
 		unsafe {
@@ -121,11 +113,10 @@ impl MainPass
 		];
 		let descriptor_pool_info = vk::DescriptorPoolCreateInfo {
 			s_type: vk::StructureType::DESCRIPTOR_POOL_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			pool_size_count: descriptor_sizes.len() as u32,
 			p_pool_sizes: descriptor_sizes.as_ptr(),
 			max_sets: 8, // TODO figure out how to properly do this
+			..Default::default()
 		};
 		let descriptor_pool;
 		unsafe {
@@ -156,17 +147,15 @@ impl MainPass
 		}];
 		let color_normal_tex_info = vk::DescriptorSetLayoutCreateInfo {
 			s_type: vk::StructureType::DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			binding_count: color_normal_tex_dsl_bindings.len() as u32,
 			p_bindings: color_normal_tex_dsl_bindings.as_ptr(),
+			..Default::default()
 		};
 		let view_matrix_info = vk::DescriptorSetLayoutCreateInfo {
 			s_type: vk::StructureType::DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			binding_count: view_matrix_dsl_binding.len() as u32,
 			p_bindings: view_matrix_dsl_binding.as_ptr(),
+			..Default::default()
 		};
 
 		let descriptor_set_layouts;
@@ -185,12 +174,11 @@ impl MainPass
 
 		let layout_create_info = vk::PipelineLayoutCreateInfo {
 			s_type: vk::StructureType::PIPELINE_LAYOUT_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			set_layout_count: descriptor_set_layouts.len() as u32,
 			p_set_layouts: descriptor_set_layouts.as_ptr(),
 			push_constant_range_count: 1,
 			p_push_constant_ranges: &mv_matrices_push_constant,
+			..Default::default()
 		};
 
 		let pipeline_layout;
@@ -205,21 +193,17 @@ impl MainPass
 		let shader_stage_create_infos = [
 			vk::PipelineShaderStageCreateInfo {
 				s_type: vk::StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
-				p_next: ptr::null(),
-				flags: Default::default(),
 				module: vertex_shader_module,
 				p_name: shader_entry_name.as_ptr(),
-				p_specialization_info: ptr::null(),
 				stage: vk::ShaderStageFlags::VERTEX,
+				..Default::default()
 			},
 			vk::PipelineShaderStageCreateInfo {
 				s_type: vk::StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
-				p_next: ptr::null(),
-				flags: Default::default(),
 				module: fragment_shader_module,
 				p_name: shader_entry_name.as_ptr(),
-				p_specialization_info: ptr::null(),
 				stage: vk::ShaderStageFlags::FRAGMENT,
+				..Default::default()
 			},
 		];
 
@@ -309,99 +293,67 @@ impl MainPass
 		};
 		let viewport_state_info = vk::PipelineViewportStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_VIEWPORT_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			scissor_count: 1,
 			p_scissors: &scissor,
 			viewport_count: 1,
 			p_viewports: &viewport,
+			..Default::default()
 		};
 		let rasterization_info = vk::PipelineRasterizationStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			cull_mode: vk::CullModeFlags::BACK,
-			depth_bias_clamp: 0.0,
-			depth_bias_constant_factor: 0.0,
-			depth_bias_enable: 0,
-			depth_bias_slope_factor: 0.0,
-			depth_clamp_enable: 0,
 			front_face: vk::FrontFace::COUNTER_CLOCKWISE,
 			line_width: 1.0,
 			polygon_mode: vk::PolygonMode::FILL,
-			rasterizer_discard_enable: 0,
+			..Default::default()
 		};
 		let multisample_state_info = vk::PipelineMultisampleStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			rasterization_samples: vk::SampleCountFlags::TYPE_1,
-			sample_shading_enable: 0,
-			min_sample_shading: 0.0,
-			p_sample_mask: ptr::null(),
-			alpha_to_one_enable: 0,
-			alpha_to_coverage_enable: 0,
+			..Default::default()
 		};
 		let noop_stencil_state = vk::StencilOpState {
 			fail_op: vk::StencilOp::KEEP,
 			pass_op: vk::StencilOp::KEEP,
 			depth_fail_op: vk::StencilOp::KEEP,
 			compare_op: vk::CompareOp::ALWAYS,
-			compare_mask: 0,
-			write_mask: 0,
-			reference: 0,
+			..Default::default()
 		};
 		let depth_state_info = vk::PipelineDepthStencilStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			depth_test_enable: 1,
 			depth_write_enable: 1,
 			depth_compare_op: vk::CompareOp::LESS_OR_EQUAL,
-			depth_bounds_test_enable: 0,
-			stencil_test_enable: 0,
 			front: noop_stencil_state.clone(),
 			back: noop_stencil_state.clone(),
 			max_depth_bounds: 1.0,
 			min_depth_bounds: 0.0,
+			..Default::default()
 		};
 		let color_blend_attachment_states = [vk::PipelineColorBlendAttachmentState {
 			blend_enable: 0,
-			src_color_blend_factor: vk::BlendFactor::SRC_COLOR,
-			dst_color_blend_factor: vk::BlendFactor::ONE_MINUS_DST_COLOR,
-			color_blend_op: vk::BlendOp::ADD,
-			src_alpha_blend_factor: vk::BlendFactor::ZERO,
-			dst_alpha_blend_factor: vk::BlendFactor::ZERO,
-			alpha_blend_op: vk::BlendOp::ADD,
 			color_write_mask: vk::ColorComponentFlags::all(),
+			..Default::default()
 		}];
 		let color_blend_state = vk::PipelineColorBlendStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
-			logic_op_enable: 0,
-			logic_op: vk::LogicOp::CLEAR,
 			attachment_count: color_blend_attachment_states.len() as u32,
 			p_attachments: color_blend_attachment_states.as_ptr(),
-			blend_constants: [0.0, 0.0, 0.0, 0.0],
+			..Default::default()
 		};
 		let dynamic_state = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
 		let dynamic_state_info = vk::PipelineDynamicStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_DYNAMIC_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			dynamic_state_count: dynamic_state.len() as u32,
 			p_dynamic_states: dynamic_state.as_ptr(),
+			..Default::default()
 		};
 		let graphic_pipeline_info = vk::GraphicsPipelineCreateInfo {
 			s_type: vk::StructureType::GRAPHICS_PIPELINE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: vk::PipelineCreateFlags::empty(),
 			stage_count: shader_stage_create_infos.len() as u32,
 			p_stages: shader_stage_create_infos.as_ptr(),
 			p_vertex_input_state: &vertex_input_state_info,
 			p_input_assembly_state: &vertex_input_assembly_state_info,
-			p_tessellation_state: ptr::null(),
 			p_viewport_state: &viewport_state_info,
 			p_rasterization_state: &rasterization_info,
 			p_multisample_state: &multisample_state_info,
@@ -410,9 +362,7 @@ impl MainPass
 			p_dynamic_state: &dynamic_state_info,
 			layout: pipeline_layout,
 			render_pass: renderpass,
-			subpass: 0,
-			base_pipeline_handle: vk::Pipeline::null(),
-			base_pipeline_index: 0,
+			..Default::default()
 		};
 		let graphics_pipelines;
 		unsafe {
@@ -438,14 +388,13 @@ impl MainPass
 		let framebuffer_attachments = [color_view, depth_view];
 		let frame_buffer_create_info = vk::FramebufferCreateInfo {
 			s_type: vk::StructureType::FRAMEBUFFER_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			render_pass: renderpass,
 			attachment_count: framebuffer_attachments.len() as u32,
 			p_attachments: framebuffer_attachments.as_ptr(),
 			width: render_size.width,
 			height: render_size.height,
 			layers: 1,
+			..Default::default()
 		};
 		let framebuffer;
 		unsafe {
@@ -564,9 +513,8 @@ impl MainPass
 		// Begin commandbuffer
 		let cmd_buf_begin_info = vk::CommandBufferBeginInfo {
 			s_type: vk::StructureType::COMMAND_BUFFER_BEGIN_INFO,
-			p_next: ptr::null(),
-			p_inheritance_info: ptr::null(),
-			flags: vk::CommandBufferUsageFlags::SIMULTANEOUS_USE,
+			flags: vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT,
+			..Default::default()
 		};
 		let cmd_buf = self.commandbuffer;
 		unsafe {
@@ -614,15 +562,13 @@ impl MainPass
 		};
 		let write_desc_sets = [vk::WriteDescriptorSet {
 			s_type: vk::StructureType::WRITE_DESCRIPTOR_SET,
-			p_next: ptr::null(),
 			dst_set: self.view_matrix_ds[0],
 			dst_binding: 0,
 			dst_array_element: 0,
 			descriptor_count: 1,
 			descriptor_type: vk::DescriptorType::UNIFORM_BUFFER,
-			p_image_info: ptr::null(),
 			p_buffer_info: &view_matrix_ub_descriptor,
-			p_texel_buffer_view: ptr::null(),
+			..Default::default()
 		}];
 
 		unsafe {
@@ -665,14 +611,9 @@ impl MainPass
 		// Send the work off to the GPU
 		let submit_info = vk::SubmitInfo {
 			s_type: vk::StructureType::SUBMIT_INFO,
-			p_next: ptr::null(),
-			wait_semaphore_count: 0,
-			p_wait_semaphores: ptr::null(),
-			p_wait_dst_stage_mask: ptr::null(),
 			command_buffer_count: 1,
 			p_command_buffers: &cmd_buf,
-			signal_semaphore_count: 0,
-			p_signal_semaphores: ptr::null(),
+			..Default::default()
 		};
 		unsafe {
 			rs.device.queue_submit(rs.graphics_queue, &[submit_info], vk::Fence::null()).expect("queue submit failed.");

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -97,9 +97,9 @@ impl RenderState
 
 		// Only enable debug layers if requested
 		let mut layer_names_raw: Vec<*const i8> = Vec::new();
+		let requested_layers = [CString::new("VK_LAYER_KHRONOS_validation").unwrap()];
 		if cfg!(feature = "debug_layer")
 		{
-			let requested_layers = [CString::new("VK_LAYER_LUNARG_standard_validation").unwrap()];
 			println!("Debug layers:");
 			let available_layers = entry.enumerate_instance_layer_properties().unwrap();
 			for layer in available_layers.iter()
@@ -119,6 +119,7 @@ impl RenderState
 				}
 			}
 
+			debug_assert!(layer_names_raw.len() > 0);
 			println!("Will enable {} debug layers", layer_names_raw.len());
 		}
 
@@ -126,13 +127,12 @@ impl RenderState
 		let extension_names_raw = RenderState::extension_names();
 		let create_info = vk::InstanceCreateInfo {
 			s_type: vk::StructureType::INSTANCE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			p_application_info: &appinfo,
 			pp_enabled_layer_names: layer_names_raw.as_ptr(),
 			enabled_layer_count: layer_names_raw.len() as u32,
 			pp_enabled_extension_names: extension_names_raw.as_ptr(),
 			enabled_extension_count: extension_names_raw.len() as u32,
+			..Default::default()
 		};
 		let instance;
 		unsafe {
@@ -159,12 +159,11 @@ impl RenderState
 	{
 		let debug_info = vk::DebugReportCallbackCreateInfoEXT {
 			s_type: vk::StructureType::DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
-			p_next: ptr::null(),
 			flags: vk::DebugReportFlagsEXT::ERROR |
 				vk::DebugReportFlagsEXT::WARNING |
 				vk::DebugReportFlagsEXT::PERFORMANCE_WARNING,
 			pfn_callback: Some(RenderState::vulkan_debug_callback),
-			p_user_data: ptr::null_mut(),
+			..Default::default()
 		};
 		let debug_report_loader = DebugReport::new(entry, instance);
 		let debug_callback;
@@ -218,11 +217,10 @@ impl RenderState
 		let queue_priorities = [1.0]; // One queue of priority 1.0
 		let queue_info = vk::DeviceQueueCreateInfo {
 			s_type: vk::StructureType::DEVICE_QUEUE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			queue_family_index: queue_family_index,
 			p_queue_priorities: queue_priorities.as_ptr(),
 			queue_count: queue_priorities.len() as u32,
+			..Default::default()
 		};
 		let device_extension_names_raw = [Swapchain::name().as_ptr()]; // VK_KHR_swapchain
 		let features = vk::PhysicalDeviceFeatures {
@@ -232,15 +230,12 @@ impl RenderState
 		};
 		let device_create_info = vk::DeviceCreateInfo {
 			s_type: vk::StructureType::DEVICE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			queue_create_info_count: 1,
 			p_queue_create_infos: &queue_info,
-			enabled_layer_count: 0,
-			pp_enabled_layer_names: ptr::null(),
 			enabled_extension_count: device_extension_names_raw.len() as u32,
 			pp_enabled_extension_names: device_extension_names_raw.as_ptr(),
 			p_enabled_features: &features,
+			..Default::default()
 		};
 		let device;
 		unsafe {
@@ -360,9 +355,8 @@ impl RenderState
 
 		let cmd_buf_begin_info = vk::CommandBufferBeginInfo {
 			s_type: vk::StructureType::COMMAND_BUFFER_BEGIN_INFO,
-			p_next: ptr::null(),
-			p_inheritance_info: ptr::null(),
 			flags: vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT,
+			..Default::default()
 		};
 		unsafe {
 			self.device.begin_command_buffer(cmd_buf, &cmd_buf_begin_info).expect("Begin commandbuffer");
@@ -380,14 +374,9 @@ impl RenderState
 
 		let submit_info = vk::SubmitInfo {
 			s_type: vk::StructureType::SUBMIT_INFO,
-			p_next: ptr::null(),
-			wait_semaphore_count: 0,
-			p_wait_semaphores: ptr::null(),
-			p_wait_dst_stage_mask: ptr::null(),
 			command_buffer_count: 1,
 			p_command_buffers: &cmd_buf,
-			signal_semaphore_count: 0,
-			p_signal_semaphores: ptr::null(),
+			..Default::default()
 		};
 		unsafe {
 			self.device
@@ -405,13 +394,10 @@ impl RenderState
 	{
 		let bufferinfo = vk::BufferCreateInfo {
 			s_type: vk::StructureType::BUFFER_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: vk::BufferCreateFlags::empty(),
 			size: buffersize,
 			usage: usage,
 			sharing_mode: vk::SharingMode::EXCLUSIVE,
-			queue_family_index_count: 0,
-			p_queue_family_indices: ptr::null(),
+			..Default::default()
 		};
 
 		let buffer;
@@ -529,10 +515,9 @@ impl RenderState
 		let shader_bytes: Vec<u8> = spv_file.bytes().filter_map(|byte| byte.ok()).collect();
 		let shader_info = vk::ShaderModuleCreateInfo {
 			s_type: vk::StructureType::SHADER_MODULE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			code_size: shader_bytes.len(),
 			p_code: shader_bytes.as_ptr() as *const u32,
+			..Default::default()
 		};
 		let shader_module;
 		unsafe {
@@ -559,8 +544,6 @@ impl RenderState
 
 		let texture_create_info = vk::ImageCreateInfo {
 			s_type: vk::StructureType::IMAGE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			image_type: texture_type,
 			format: texture_format,
 			extent: texture_dimensions,
@@ -570,9 +553,8 @@ impl RenderState
 			tiling: vk::ImageTiling::OPTIMAL,
 			usage: texture_usage,
 			sharing_mode: vk::SharingMode::EXCLUSIVE,
-			queue_family_index_count: 0,
-			p_queue_family_indices: ptr::null(),
 			initial_layout: vk::ImageLayout::UNDEFINED,
+			..Default::default()
 		};
 		let texture_image;
 		let texture_memory_req;
@@ -604,13 +586,9 @@ impl RenderState
 				// First transition the Image to TransferDstOptimal
 				let texture_barrier = vk::ImageMemoryBarrier {
 					s_type: vk::StructureType::IMAGE_MEMORY_BARRIER,
-					p_next: ptr::null(),
-					src_access_mask: Default::default(),
 					dst_access_mask: vk::AccessFlags::TRANSFER_WRITE,
 					old_layout: vk::ImageLayout::UNDEFINED,
 					new_layout: vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-					src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-					dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
 					image: texture_image,
 					subresource_range: vk::ImageSubresourceRange {
 						aspect_mask: texture_aspect_mask,
@@ -619,6 +597,7 @@ impl RenderState
 						base_array_layer: 0,
 						layer_count: 1,
 					},
+					..Default::default()
 				};
 				unsafe {
 					self.device.cmd_pipeline_barrier(
@@ -661,13 +640,10 @@ impl RenderState
 				// Finally transition the Image to the correct layout
 				let texture_barrier = vk::ImageMemoryBarrier {
 					s_type: vk::StructureType::IMAGE_MEMORY_BARRIER,
-					p_next: ptr::null(),
 					src_access_mask: vk::AccessFlags::TRANSFER_WRITE,
 					dst_access_mask: initial_access_mask,
 					old_layout: vk::ImageLayout::TRANSFER_DST_OPTIMAL,
 					new_layout: initial_layout,
-					src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-					dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
 					image: texture_image,
 					subresource_range: vk::ImageSubresourceRange {
 						aspect_mask: texture_aspect_mask,
@@ -676,6 +652,7 @@ impl RenderState
 						base_array_layer: 0,
 						layer_count: 1,
 					},
+					..Default::default()
 				};
 				unsafe {
 					self.device.cmd_pipeline_barrier(
@@ -694,13 +671,9 @@ impl RenderState
 			{
 				let texture_barrier = vk::ImageMemoryBarrier {
 					s_type: vk::StructureType::IMAGE_MEMORY_BARRIER,
-					p_next: ptr::null(),
-					src_access_mask: Default::default(),
 					dst_access_mask: initial_access_mask,
 					old_layout: vk::ImageLayout::UNDEFINED,
 					new_layout: initial_layout,
-					src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-					dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
 					image: texture_image,
 					subresource_range: vk::ImageSubresourceRange {
 						aspect_mask: texture_aspect_mask,
@@ -709,6 +682,7 @@ impl RenderState
 						base_array_layer: 0,
 						layer_count: 1,
 					},
+					..Default::default()
 				};
 				unsafe {
 					self.device.cmd_pipeline_barrier(
@@ -728,8 +702,6 @@ impl RenderState
 		// Create texture image view
 		let tex_image_view_info = vk::ImageViewCreateInfo {
 			s_type: vk::StructureType::IMAGE_VIEW_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			view_type: texture_view_type,
 			format: texture_create_info.format,
 			components: vk::ComponentMapping {
@@ -746,6 +718,7 @@ impl RenderState
 				layer_count: 1,
 			},
 			image: texture_image,
+			..Default::default()
 		};
 		let texture_view;
 		unsafe {
@@ -755,23 +728,14 @@ impl RenderState
 		// Create sampler
 		let sampler_info = vk::SamplerCreateInfo {
 			s_type: vk::StructureType::SAMPLER_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			mag_filter: vk::Filter::LINEAR,
 			min_filter: vk::Filter::LINEAR,
 			mipmap_mode: vk::SamplerMipmapMode::LINEAR,
 			address_mode_u: vk::SamplerAddressMode::MIRRORED_REPEAT,
 			address_mode_v: vk::SamplerAddressMode::MIRRORED_REPEAT,
 			address_mode_w: vk::SamplerAddressMode::MIRRORED_REPEAT,
-			mip_lod_bias: 0.0,
-			min_lod: 0.0,
-			max_lod: 0.0,
-			anisotropy_enable: 0,
-			max_anisotropy: 1.0,
 			border_color: vk::BorderColor::FLOAT_OPAQUE_WHITE,
-			compare_enable: 0,
-			compare_op: vk::CompareOp::NEVER,
-			unnormalized_coordinates: 0,
+			..Default::default()
 		};
 		let sampler;
 		unsafe {
@@ -862,13 +826,10 @@ impl RenderState
 
 		let texture_barrier = vk::ImageMemoryBarrier {
 			s_type: vk::StructureType::IMAGE_MEMORY_BARRIER,
-			p_next: ptr::null(),
 			src_access_mask: texture.current_access_mask,
 			dst_access_mask: new_access_mask,
 			old_layout: texture.current_layout,
 			new_layout: new_layout,
-			src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-			dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
 			image: texture.image,
 			subresource_range: vk::ImageSubresourceRange {
 				aspect_mask: vk::ImageAspectFlags::COLOR,
@@ -877,6 +838,7 @@ impl RenderState
 				base_array_layer: 0,
 				layer_count: 1,
 			},
+			..Default::default()
 		};
 
 		match opt_cmd_buf

--- a/src/renderer/presentpass.rs
+++ b/src/renderer/presentpass.rs
@@ -88,8 +88,6 @@ impl PresentPass
 		let present_mode = present_modes.iter().cloned().find(|&mode| mode == vk::PresentModeKHR::FIFO).unwrap();
 		let swapchain_create_info = vk::SwapchainCreateInfoKHR {
 			s_type: vk::StructureType::SWAPCHAIN_CREATE_INFO_KHR,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			surface: *surface,
 			min_image_count: desired_image_count,
 			image_color_space: surface_format.color_space,
@@ -103,8 +101,7 @@ impl PresentPass
 			clipped: 1,
 			old_swapchain: old_swapchain,
 			image_array_layers: 1,
-			p_queue_family_indices: ptr::null(),
-			queue_family_index_count: 0,
+			..Default::default()
 		};
 		let swapchain;
 		unsafe {
@@ -141,8 +138,6 @@ impl PresentPass
 			.map(|&image| {
 				let create_view_info = vk::ImageViewCreateInfo {
 					s_type: vk::StructureType::IMAGE_VIEW_CREATE_INFO,
-					p_next: ptr::null(),
-					flags: Default::default(),
 					view_type: vk::ImageViewType::TYPE_2D,
 					format: surface_format.format,
 					components: vk::ComponentMapping {
@@ -159,6 +154,7 @@ impl PresentPass
 						layer_count: 1,
 					},
 					image: image,
+					..Default::default()
 				};
 				let result;
 				unsafe { result = rs.device.create_image_view(&create_view_info, None).unwrap() }
@@ -193,25 +189,16 @@ impl PresentPass
 		let subpass = vk::SubpassDescription {
 			color_attachment_count: 1,
 			p_color_attachments: &color_attachment_ref,
-			p_depth_stencil_attachment: ptr::null(),
-			flags: Default::default(),
 			pipeline_bind_point: vk::PipelineBindPoint::GRAPHICS,
-			input_attachment_count: 0,
-			p_input_attachments: ptr::null(),
-			p_resolve_attachments: ptr::null(),
-			preserve_attachment_count: 0,
-			p_preserve_attachments: ptr::null(),
+			..Default::default()
 		};
 		let renderpass_create_info = vk::RenderPassCreateInfo {
 			s_type: vk::StructureType::RENDER_PASS_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			attachment_count: renderpass_attachments.len() as u32,
 			p_attachments: renderpass_attachments.as_ptr(),
 			subpass_count: 1,
 			p_subpasses: &subpass,
-			dependency_count: 0,
-			p_dependencies: ptr::null(),
+			..Default::default()
 		};
 		let renderpass;
 		unsafe {
@@ -243,11 +230,10 @@ impl PresentPass
 		}];
 		let descriptor_pool_info = vk::DescriptorPoolCreateInfo {
 			s_type: vk::StructureType::DESCRIPTOR_POOL_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			pool_size_count: descriptor_sizes.len() as u32,
 			p_pool_sizes: descriptor_sizes.as_ptr(),
 			max_sets: 1,
+			..Default::default()
 		};
 		let descriptor_pool;
 		unsafe {
@@ -262,10 +248,9 @@ impl PresentPass
 		}];
 		let descriptor_info = vk::DescriptorSetLayoutCreateInfo {
 			s_type: vk::StructureType::DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			binding_count: desc_layout_bindings.len() as u32,
 			p_bindings: desc_layout_bindings.as_ptr(),
+			..Default::default()
 		};
 		let descriptor_set_layouts;
 		unsafe {
@@ -284,12 +269,9 @@ impl PresentPass
 		}
 		let layout_create_info = vk::PipelineLayoutCreateInfo {
 			s_type: vk::StructureType::PIPELINE_LAYOUT_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			set_layout_count: descriptor_set_layouts.len() as u32,
 			p_set_layouts: descriptor_set_layouts.as_ptr(),
-			push_constant_range_count: 0,
-			p_push_constant_ranges: ptr::null(),
+			..Default::default()
 		};
 
 		let pipeline_layout;
@@ -304,40 +286,33 @@ impl PresentPass
 		let shader_stage_create_infos = [
 			vk::PipelineShaderStageCreateInfo {
 				s_type: vk::StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
-				p_next: ptr::null(),
-				flags: Default::default(),
 				module: vertex_shader_module,
 				p_name: shader_entry_name.as_ptr(),
-				p_specialization_info: ptr::null(),
 				stage: vk::ShaderStageFlags::VERTEX,
+				..Default::default()
 			},
 			vk::PipelineShaderStageCreateInfo {
 				s_type: vk::StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
-				p_next: ptr::null(),
-				flags: Default::default(),
 				module: fragment_shader_module,
 				p_name: shader_entry_name.as_ptr(),
-				p_specialization_info: ptr::null(),
 				stage: vk::ShaderStageFlags::FRAGMENT,
+				..Default::default()
 			},
 		];
 		let vertex_input_binding_descriptions = [];
 		let vertex_input_attribute_descriptions = [];
 		let vertex_input_state_info = vk::PipelineVertexInputStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			vertex_attribute_description_count: vertex_input_attribute_descriptions.len() as u32,
 			p_vertex_attribute_descriptions: vertex_input_attribute_descriptions.as_ptr(),
 			vertex_binding_description_count: vertex_input_binding_descriptions.len() as u32,
 			p_vertex_binding_descriptions: vertex_input_binding_descriptions.as_ptr(),
+			..Default::default()
 		};
 		let vertex_input_assembly_state_info = vk::PipelineInputAssemblyStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
-			primitive_restart_enable: 0,
 			topology: vk::PrimitiveTopology::TRIANGLE_LIST,
+			..Default::default()
 		};
 		let viewport = vk::Viewport {
 			x: surface_size.offset.x as f32,
@@ -350,99 +325,66 @@ impl PresentPass
 		let scissor = surface_size.clone();
 		let viewport_state_info = vk::PipelineViewportStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_VIEWPORT_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			scissor_count: 1,
 			p_scissors: &scissor,
 			viewport_count: 1,
 			p_viewports: &viewport,
+			..Default::default()
 		};
 		let rasterization_info = vk::PipelineRasterizationStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			cull_mode: vk::CullModeFlags::BACK,
-			depth_bias_clamp: 0.0,
-			depth_bias_constant_factor: 0.0,
-			depth_bias_enable: 0,
-			depth_bias_slope_factor: 0.0,
-			depth_clamp_enable: 0,
 			front_face: vk::FrontFace::COUNTER_CLOCKWISE,
 			line_width: 1.0,
 			polygon_mode: vk::PolygonMode::FILL,
-			rasterizer_discard_enable: 0,
+			..Default::default()
 		};
 		let multisample_state_info = vk::PipelineMultisampleStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			rasterization_samples: vk::SampleCountFlags::TYPE_1,
-			sample_shading_enable: 0,
-			min_sample_shading: 0.0,
-			p_sample_mask: ptr::null(),
-			alpha_to_one_enable: 0,
-			alpha_to_coverage_enable: 0,
+			..Default::default()
 		};
 		let noop_stencil_state = vk::StencilOpState {
 			fail_op: vk::StencilOp::KEEP,
 			pass_op: vk::StencilOp::KEEP,
 			depth_fail_op: vk::StencilOp::KEEP,
 			compare_op: vk::CompareOp::ALWAYS,
-			compare_mask: 0,
-			write_mask: 0,
-			reference: 0,
+			..Default::default()
 		};
 		let depth_state_info = vk::PipelineDepthStencilStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			depth_test_enable: 1,
 			depth_write_enable: 1,
 			depth_compare_op: vk::CompareOp::LESS_OR_EQUAL,
-			depth_bounds_test_enable: 0,
-			stencil_test_enable: 0,
 			front: noop_stencil_state.clone(),
 			back: noop_stencil_state.clone(),
 			max_depth_bounds: 1.0,
 			min_depth_bounds: 0.0,
+			..Default::default()
 		};
 		let color_blend_attachment_states = [vk::PipelineColorBlendAttachmentState {
-			blend_enable: 0,
-			src_color_blend_factor: vk::BlendFactor::SRC_COLOR,
-			dst_color_blend_factor: vk::BlendFactor::ONE_MINUS_DST_COLOR,
-			color_blend_op: vk::BlendOp::ADD,
-			src_alpha_blend_factor: vk::BlendFactor::ZERO,
-			dst_alpha_blend_factor: vk::BlendFactor::ZERO,
-			alpha_blend_op: vk::BlendOp::ADD,
 			color_write_mask: vk::ColorComponentFlags::all(),
+			..Default::default()
 		}];
 		let color_blend_state = vk::PipelineColorBlendStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
-			logic_op_enable: 0,
-			logic_op: vk::LogicOp::CLEAR,
 			attachment_count: color_blend_attachment_states.len() as u32,
 			p_attachments: color_blend_attachment_states.as_ptr(),
-			blend_constants: [0.0, 0.0, 0.0, 0.0],
+			..Default::default()
 		};
 		let dynamic_state = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
 		let dynamic_state_info = vk::PipelineDynamicStateCreateInfo {
 			s_type: vk::StructureType::PIPELINE_DYNAMIC_STATE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
 			dynamic_state_count: dynamic_state.len() as u32,
 			p_dynamic_states: dynamic_state.as_ptr(),
+			..Default::default()
 		};
 		let graphic_pipeline_info = vk::GraphicsPipelineCreateInfo {
 			s_type: vk::StructureType::GRAPHICS_PIPELINE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: vk::PipelineCreateFlags::empty(),
 			stage_count: shader_stage_create_infos.len() as u32,
 			p_stages: shader_stage_create_infos.as_ptr(),
 			p_vertex_input_state: &vertex_input_state_info,
 			p_input_assembly_state: &vertex_input_assembly_state_info,
-			p_tessellation_state: ptr::null(),
 			p_viewport_state: &viewport_state_info,
 			p_rasterization_state: &rasterization_info,
 			p_multisample_state: &multisample_state_info,
@@ -451,9 +393,7 @@ impl PresentPass
 			p_dynamic_state: &dynamic_state_info,
 			layout: pipeline_layout,
 			render_pass: renderpass,
-			subpass: 0,
-			base_pipeline_handle: vk::Pipeline::null(),
-			base_pipeline_index: 0,
+			..Default::default()
 		};
 		let graphics_pipelines;
 		unsafe {
@@ -490,14 +430,13 @@ impl PresentPass
 				let framebuffer_attachments = [present_image_view];
 				let frame_buffer_create_info = vk::FramebufferCreateInfo {
 					s_type: vk::StructureType::FRAMEBUFFER_CREATE_INFO,
-					p_next: ptr::null(),
-					flags: Default::default(),
 					render_pass: renderpass,
 					attachment_count: framebuffer_attachments.len() as u32,
 					p_attachments: framebuffer_attachments.as_ptr(),
 					width: surface_size.extent.width,
 					height: surface_size.extent.height,
 					layers: 1,
+					..Default::default()
 				};
 				let framebuffer;
 				unsafe {
@@ -563,8 +502,7 @@ impl PresentPass
 
 		let sem_create_info = vk::SemaphoreCreateInfo {
 			s_type: vk::StructureType::SEMAPHORE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: Default::default(),
+			..Default::default()
 		};
 		let image_available_sem;
 		let rendering_finished_sem;
@@ -754,12 +692,10 @@ impl PresentPass
 		// Begin renderpass
 		let render_pass_begin_info = vk::RenderPassBeginInfo {
 			s_type: vk::StructureType::RENDER_PASS_BEGIN_INFO,
-			p_next: ptr::null(),
 			render_pass: self.renderpass,
 			framebuffer: self.framebuffers[self.current_present_idx],
 			render_area: self.scissor,
-			clear_value_count: 0,
-			p_clear_values: ptr::null(),
+			..Default::default()
 		};
 		unsafe {
 			// Start the render pass
@@ -792,8 +728,7 @@ impl PresentPass
 		// Send the work off to the GPU
 		let fence_create_info = vk::FenceCreateInfo {
 			s_type: vk::StructureType::FENCE_CREATE_INFO,
-			p_next: ptr::null(),
-			flags: vk::FenceCreateFlags::empty(),
+			..Default::default()
 		};
 		let submit_fence;
 		unsafe {
@@ -818,13 +753,12 @@ impl PresentPass
 
 		let present_info = vk::PresentInfoKHR {
 			s_type: vk::StructureType::PRESENT_INFO_KHR,
-			p_next: ptr::null(),
 			wait_semaphore_count: 1,
 			p_wait_semaphores: &self.rendering_finished_sem,
 			swapchain_count: 1,
 			p_swapchains: &self.swapchain,
 			p_image_indices: &(self.current_present_idx as u32),
-			p_results: ptr::null_mut(),
+			..Default::default()
 		};
 		let result;
 		unsafe {
@@ -876,15 +810,13 @@ impl PresentPass
 		};
 		let write_desc_sets = [vk::WriteDescriptorSet {
 			s_type: vk::StructureType::WRITE_DESCRIPTOR_SET,
-			p_next: ptr::null(),
 			dst_set: self.descriptor_sets[0],
 			dst_binding: 0,
 			dst_array_element: 0,
 			descriptor_count: 1,
 			descriptor_type: vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
 			p_image_info: &image_descriptor,
-			p_buffer_info: ptr::null(),
-			p_texel_buffer_view: ptr::null(),
+			..Default::default()
 		}];
 		unsafe {
 			// Update the descriptor set for the image to draw


### PR DESCRIPTION
As winit no longer fits this implementation, this commit replaces winit
with SDL2 for window and event handling.